### PR TITLE
Also account for the INVITE_SENT state for nisct/info transactions

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -691,7 +691,9 @@ Session.prototype = {
         }
         break;
       case SIP.C.INFO:
-        if(this.status === C.STATUS_CONFIRMED || this.status === C.STATUS_WAITING_FOR_ACK) {
+        if(this.status === C.STATUS_CONFIRMED ||
+          this.status === C.STATUS_WAITING_FOR_ACK ||
+          this.status === C.STATUS_INVITE_SENT) {
           var body, tone, duration,
               contentType = request.getHeader('content-type'),
               reg_tone = /^(Signal\s*?=\s*?)([0-9A-D#*]{1})(\s)?.*/,


### PR DESCRIPTION
This solves an issue with INFO requests being stored forever and preventing the UA being closed due to freaking state mismatches.

Might happen with other req/responses, but I'd need more time to investigate that. So I'll use this to release a quick patch release.