### PR TITLE
Also account for the 1XX_RECEIVED state for nisct-info transactions

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -693,7 +693,8 @@ Session.prototype = {
       case SIP.C.INFO:
         if(this.status === C.STATUS_CONFIRMED ||
           this.status === C.STATUS_WAITING_FOR_ACK ||
-          this.status === C.STATUS_INVITE_SENT) {
+          this.status === C.STATUS_INVITE_SENT ||
+          this.status === C.STATUS_1XX_RECEIVED) {
           var body, tone, duration,
               contentType = request.getHeader('content-type'),
               reg_tone = /^(Signal\s*?=\s*?)([0-9A-D#*]{1})(\s)?.*/,


### PR DESCRIPTION
Some endpoints shortcut the allowed methods announcement to non provisional 1XX  responses and send INFO requests before the initial dialog was confirmed. This caused the INFO requests that came before the INVITE dialog was confirmed to fall into a limbo. Our UA would be unresponsive to them, causing the dialog to be ended by the remote end due to retransmission timeouts.